### PR TITLE
Define headers to be replaced

### DIFF
--- a/Subscriber/Frontend.php
+++ b/Subscriber/Frontend.php
@@ -50,25 +50,25 @@ class Frontend implements SubscriberInterface
     private function setSecurityHeaders(\Enlight_Controller_Response_ResponseHttp $response)
     {
         if ($this->config['strictTransportSecurityEnabled']) {
-            $response->setHeader('Strict-Transport-Security', $this->config['strictTransportSecurity']);
+            $response->setHeader('Strict-Transport-Security', $this->config['strictTransportSecurity'], true);
         }
         if ($this->config['xFrameOptionsEnabled']) {
-            $response->setHeader('X-Frame-Options', $this->config['xFrameOptions']);
+            $response->setHeader('X-Frame-Options', $this->config['xFrameOptions'], true);
         }
         if ($this->config['xXssProtectionEnabled']) {
-            $response->setHeader('X-XSS-Protection', $this->config['xXssProtection']);
+            $response->setHeader('X-XSS-Protection', $this->config['xXssProtection'], true);
         }
         if ($this->config['xContentTypeOptionsEnabled']) {
-            $response->setHeader('X-Content-Type-Options', $this->config['xContentTypeOptions']);
+            $response->setHeader('X-Content-Type-Options', $this->config['xContentTypeOptions'], true);
         }
         if ($this->config['referrerPolicyEnabled']) {
-            $response->setHeader('Referrer-Policy', $this->config['referrerPolicy']);
+            $response->setHeader('Referrer-Policy', $this->config['referrerPolicy'], true);
         }
         if ($this->config['contentSecurityPolicyEnabled'] && $this->isSecure()) {
             if ($this->config['contentSecurityPolicyDebug']) {
-                $response->setHeader('Content-Security-Policy-Report-Only', $this->config['contentSecurityPolicy']);
+                $response->setHeader('Content-Security-Policy-Report-Only', $this->config['contentSecurityPolicy'], true);
             } else {
-                $response->setHeader('Content-Security-Policy', $this->config['contentSecurityPolicy']);
+                $response->setHeader('Content-Security-Policy', $this->config['contentSecurityPolicy'], true);
             }
         }
     }
@@ -79,7 +79,7 @@ class Frontend implements SubscriberInterface
     private function setCustomHeaders(\Enlight_Controller_Response_ResponseHttp $response)
     {
         foreach ($this->getCustomHeaders() as $header => $value) {
-            $response->setHeader($header, $value);
+            $response->setHeader($header, $value, true);
         }
     }
 


### PR DESCRIPTION
you should explicit replace the headers, due to duplicated entries at forwarded requests